### PR TITLE
Add AI Explorer tab with querychat integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 __pycache__/
 *.pyc
 *.pyo
+.env
+
+.env

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,7 @@ starlette==0.52.1
 anyio==4.12.1
 requests==2.32.5
 libsass==0.23.0
+querychat==0.5.1
+chatlas==0.15.2
+duckdb==1.4.4
+python-dotenv==1.2.2

--- a/src/app.py
+++ b/src/app.py
@@ -1,142 +1,206 @@
+import os
 import pandas as pd
 import matplotlib.pyplot as plt
+from dotenv import load_dotenv
 from shiny import App, reactive, render, ui
 import plotly.express as px
+from querychat import QueryChat
+
+# Load ANTHROPIC_API_KEY from .env
+load_dotenv()
 
 # =============================================================================
-# RAHIQ — Data loading and sidebar filter controls
-# Branch: feat/filter-controls
+# Data loading
 # =============================================================================
-
-# ── Data ──────────────────────────────────────────────────────────────────────
 df = pd.read_csv("data/raw/spotify_songs.csv")
 df = df.drop_duplicates(subset="track_id")
 df["duration_s"] = (df["duration_ms"] / 1000).round(1)
 
-# ── UI ────────────────────────────────────────────────────────────────────────
-app_ui = ui.page_fluid(
+# =============================================================================
+# QueryChat — initialized once at module level with a small column subset
+# to keep the schema prompt concise and reduce token usage
+# =============================================================================
+AI_COLS = [
+    "track_name", "track_artist", "track_album_name",
+    "track_album_release_date", "playlist_genre",
+    "track_popularity", "danceability", "energy",
+    "valence", "acousticness", "tempo", "duration_s",
+]
+qc = QueryChat(
+    df[AI_COLS],
+    "spotify_songs",
+    client="anthropic/claude-haiku-4-5-20251001",
+)
 
-    # JOSE — Styled dashboard header using Bootstrap utilities (no inline CSS needed)
-    # Branch: feat/kpi-layout
-    ui.div(
-        ui.div(
-            ui.h1("🎵 Spotifind", class_="mb-0 fs-3"),
-            ui.p("Spotify Song Explorer · TidyTuesday Dataset", class_="mb-0 opacity-75 small"),
-        ),
-        ui.tags.span("v0.2.0", class_="badge bg-light text-dark"),
-        class_="bg-primary text-white p-4 d-flex justify-content-between align-items-center mb-3"
-    ),
+# =============================================================================
+# UI
+# =============================================================================
+app_ui = ui.page_navbar(
 
-    ui.layout_sidebar(
+    # ── Tab 1: Original Dashboard ────────────────────────────────────────────
+    ui.nav_panel(
+        "🎵 Dashboard",
 
-        # RAHIQ — Sidebar with accordion-grouped filters
-        ui.sidebar(
-            ui.h5("Filter Controls"),
-            ui.hr(),
-            ui.accordion(
-                ui.accordion_panel(
-                    "Audio Features",
-                    ui.input_slider("danceability", "Danceability", 0.0, 1.0, value=[0.0, 1.0], step=0.01),
-                    ui.input_slider("energy", "Energy", 0.0, 1.0, value=[0.0, 1.0], step=0.01),
-                    ui.input_slider("valence", "Valence (Mood)", 0.0, 1.0, value=[0.0, 1.0], step=0.01),
-                    ui.input_slider("acousticness", "Acousticness", 0.0, 1.0, value=[0.0, 1.0], step=0.01),
-                ),
-                ui.accordion_panel(
-                    "Track Properties",
-                    ui.input_slider("tempo", "Tempo (BPM)", 0, 250, value=[0, 250], step=1),
-                    ui.input_slider("duration_s", "Duration (seconds)", 0, 600, value=[0, 600], step=1),
-                    ui.input_slider("popularity", "Popularity (0–100)", 0, 100, value=[0, 100], step=1),
-                    ui.input_select(
-                        "genre_filter",
-                        "Genre",
-                        choices=["All"] + sorted(df["playlist_genre"].dropna().unique().tolist()),
-                        selected="All",
+        ui.layout_sidebar(
+
+            # RAHIQ — Sidebar with accordion-grouped filters
+            ui.sidebar(
+                ui.h5("Filter Controls"),
+                ui.hr(),
+                ui.accordion(
+                    ui.accordion_panel(
+                        "Audio Features",
+                        ui.input_slider("danceability", "Danceability", 0.0, 1.0, value=[0.0, 1.0], step=0.01),
+                        ui.input_slider("energy", "Energy", 0.0, 1.0, value=[0.0, 1.0], step=0.01),
+                        ui.input_slider("valence", "Valence (Mood)", 0.0, 1.0, value=[0.0, 1.0], step=0.01),
+                        ui.input_slider("acousticness", "Acousticness", 0.0, 1.0, value=[0.0, 1.0], step=0.01),
                     ),
+                    ui.accordion_panel(
+                        "Track Properties",
+                        ui.input_slider("tempo", "Tempo (BPM)", 0, 250, value=[0, 250], step=1),
+                        ui.input_slider("duration_s", "Duration (seconds)", 0, 600, value=[0, 600], step=1),
+                        ui.input_slider("popularity", "Popularity (0–100)", 0, 100, value=[0, 100], step=1),
+                        ui.input_select(
+                            "genre_filter",
+                            "Genre",
+                            choices=["All"] + sorted(df["playlist_genre"].dropna().unique().tolist()),
+                            selected="All",
+                        ),
+                    ),
+                    open=["Audio Features", "Track Properties"],
                 ),
-                open=["Audio Features", "Track Properties"],
+                ui.hr(),
+                ui.input_action_button(
+                    "reset_all", "Reset Filters",
+                    class_="btn-outline-secondary btn-sm w-100"
+                ),
+                width=260,
+                open="desktop",
             ),
-            ui.hr(),
-            ui.input_action_button(
-                "reset_all", "Reset Filters",
-                class_="btn-outline-secondary btn-sm w-100"
-            ),
-            width=260,
-            open="desktop",
-        ),
 
-        # JOSE — KPI value boxes row with Bootstrap themes
-        # Branch: feat/kpi-layout
-        ui.layout_columns(
-            ui.value_box(
-                "Songs Found",
-                ui.output_text("kpi_count"),
-                showcase=ui.tags.span("🎵", style="font-size:2.5rem;"),
-                theme="primary",
+            # JOSE — KPI value boxes
+            ui.layout_columns(
+                ui.value_box(
+                    "Songs Found",
+                    ui.output_text("kpi_count"),
+                    showcase=ui.tags.span("🎵", style="font-size:2.5rem;"),
+                    theme="primary",
+                ),
+                ui.value_box(
+                    "Avg Energy",
+                    ui.output_text("kpi_energy"),
+                    showcase=ui.tags.span("⚡", style="font-size:2.5rem;"),
+                    theme="success",
+                ),
+                ui.value_box(
+                    "Avg Danceability",
+                    ui.output_text("kpi_dance"),
+                    showcase=ui.tags.span("🕺", style="font-size:2.5rem;"),
+                    theme="info",
+                ),
+                col_widths=[4, 4, 4],
             ),
-            ui.value_box(
-                "Avg Energy",
-                ui.output_text("kpi_energy"),
-                showcase=ui.tags.span("⚡", style="font-size:2.5rem;"),
-                theme="success",
-            ),
-            ui.value_box(
-                "Avg Danceability",
-                ui.output_text("kpi_dance"),
-                showcase=ui.tags.span("🕺", style="font-size:2.5rem;"),
-                theme="info",
-            ),
-            col_widths=[4, 4, 4],
-        ),
 
-        # NGUYEN — Mood Map card
-        # Branch: feat/mood-map
-        ui.card(
-            ui.card_header("Mood Map — Valence vs Energy"),
-            ui.output_ui("plot_mood_map"),
-            #ui.output_plot("plot_mood_map", height="400px"),
-            full_screen=True,
-        ),
-
-        # SHUHANG — Results Table and Top Genres cards
-        # Branch: feat/tables
-        ui.layout_columns(
+            # NGUYEN — Mood Map card
             ui.card(
-                ui.card_header("Results Table"),
-                ui.output_data_frame("tbl_results"),
+                ui.card_header("Mood Map — Valence vs Energy"),
+                ui.output_ui("plot_mood_map"),
                 full_screen=True,
             ),
-            ui.card(
-                ui.card_header("Top Genres"),
-                #ui.output_data_frame("tbl_top_genre"),
-                ui.output_plot("tbl_top_genre"),
-            ),
-            col_widths=[8, 4],
-        ),
 
-        # JOSE — Footer
-        # Branch: feat/kpi-layout
-        ui.hr(),
-        ui.p(
-            ui.HTML(
-                "Spotifind | Data: TidyTuesday Spotify Songs | "
-                "Authors: Rahiq Raees, Nguyen Nguyen, Shuhang Li, Jose Davila | "
-                "<a href='https://github.com/UBC-MDS/DSCI-532_2026_37_Spotifind' target='_blank'>GitHub Repo</a> | "
-                "Last updated: February 2026"
+            # SHUHANG — Results Table and Top Genres cards
+            ui.layout_columns(
+                ui.card(
+                    ui.card_header("Results Table"),
+                    ui.output_data_frame("tbl_results"),
+                    full_screen=True,
+                ),
+                ui.card(
+                    ui.card_header("Top Genres"),
+                    ui.output_plot("tbl_top_genre"),
+                ),
+                col_widths=[8, 4],
             ),
-            style="color: grey; font-size: 0.8em; text-align: center;"
+
+            ui.hr(),
+            ui.p(
+                ui.HTML(
+                    "Spotifind | Data: TidyTuesday Spotify Songs | "
+                    "Authors: Rahiq Raees, Nguyen Nguyen, Shuhang Li, Jose Davila | "
+                    "<a href='https://github.com/UBC-MDS/DSCI-532_2026_37_Spotifind' target='_blank'>GitHub Repo</a> | "
+                    "Last updated: February 2026"
+                ),
+                style="color: grey; font-size: 0.8em; text-align: center;"
+            ),
         ),
     ),
 
+    # ── Tab 2: AI Explorer ───────────────────────────────────────────────────
+    ui.nav_panel(
+        "🤖 AI Explorer",
+
+        ui.layout_sidebar(
+
+            # querychat chat interface in the sidebar
+            qc.sidebar(),
+
+            # Main content area
+            ui.h4("AI-Filtered Results", class_="mb-3"),
+
+            # Download button
+            ui.download_button(
+                "download_ai_data",
+                "⬇️ Download Filtered Data",
+                class_="btn-success mb-3",
+            ),
+
+            # Filtered dataframe table
+            ui.card(
+                ui.card_header("Filtered Songs"),
+                ui.output_data_frame("ai_tbl_results"),
+                full_screen=True,
+            ),
+
+            # Visualizations driven by the AI-filtered dataframe
+            # (Team Member 2 will fill these in on feat/ai-tab-viz)
+            ui.layout_columns(
+                ui.card(
+                    ui.card_header("Mood Map — AI Filtered"),
+                    ui.output_ui("ai_plot_mood_map"),
+                    full_screen=True,
+                ),
+                ui.card(
+                    ui.card_header("Top Genres — AI Filtered"),
+                    ui.output_plot("ai_tbl_top_genre"),
+                ),
+                col_widths=[8, 4],
+            ),
+        ),
+    ),
+
+    # ── App-level header ─────────────────────────────────────────────────────
+    title=ui.div(
+        ui.span("🎵 Spotifind", class_="fw-bold"),
+        ui.span(" · Spotify Song Explorer", class_="opacity-75 small ms-2"),
+    ),
+    bg="#0d6efd",
+    inverse=True,
     theme=ui.Theme("flatly"),
 )
 
-# ── Server ────────────────────────────────────────────────────────────────────
+
+# =============================================================================
+# Server
+# =============================================================================
 def server(input, output, session):
 
+    # ── Initialize querychat server — returns session-specific reactive state ─
+    qc_state = qc.server()
+
     # =========================================================================
-    # RAHIQ — filtered_df reactive calc
-    # Branch: feat/filter-controls
+    # Tab 1 — existing server logic (unchanged)
     # =========================================================================
+
     @reactive.calc
     def filtered_df():
         data = df.copy()
@@ -153,10 +217,6 @@ def server(input, output, session):
             data = data[data["playlist_genre"] == input.genre_filter()]
         return data
 
-    # =========================================================================
-    # RAHIQ — Reset all filters when button is clicked
-    # Branch: feat/filter-controls
-    # =========================================================================
     @reactive.effect
     @reactive.event(input.reset_all)
     def _reset_filters():
@@ -169,10 +229,6 @@ def server(input, output, session):
         ui.update_slider("popularity", value=[0, 100])
         ui.update_select("genre_filter", selected="All")
 
-    # =========================================================================
-    # JOSE — KPI render functions
-    # Branch: feat/kpi-layout
-    # =========================================================================
     @render.text
     def kpi_count():
         return f"{len(filtered_df()):,} songs"
@@ -191,134 +247,118 @@ def server(input, output, session):
             return "—"
         return f"{data['danceability'].mean():.2f} / 1.0"
 
-    # =========================================================================
-    # NGUYEN — Mood Map render function
-    # Branch: feat/mood-map
-    # =========================================================================
-    # 改后（完整替换为以下内容）
     @render.ui
     def plot_mood_map():
         data = filtered_df()
-
         if data.empty:
             return ui.p("No songs match filters", style="text-align:center; padding:2rem;")
-
         sample = data.sample(min(500, len(data)), random_state=42)
-
         fig = px.scatter(
-            sample,
-            x="valence",
-            y="energy",
-            color="danceability",
+            sample, x="valence", y="energy", color="danceability",
             color_continuous_scale="viridis",
-            hover_data={
-                "track_name": True,
-                "track_artist": True,
-                "danceability": ":.2f",
-                "valence": ":.2f",
-                "energy": ":.2f",
-            },
-            labels={
-                "valence": "Valence (Sadness → Happiness)",
-                "energy": "Energy (Calm → Intense)",
-                "danceability": "Danceability",
-            },
-            title=f"Mood Map  —  {len(data):,} songs",
-            opacity=0.6,
+            hover_data={"track_name": True, "track_artist": True,
+                        "danceability": ":.2f", "valence": ":.2f", "energy": ":.2f"},
+            labels={"valence": "Valence (Sadness → Happiness)",
+                    "energy": "Energy (Calm → Intense)", "danceability": "Danceability"},
+            title=f"Mood Map  —  {len(data):,} songs", opacity=0.6,
         )
-
-        fig.add_shape(type="rect", x0=0, x1=0.5, y0=0.5, y1=1.0,
-                    fillcolor="#c0d9f5", opacity=0.25, line_width=0)
-        fig.add_shape(type="rect", x0=0.5, x1=1.0, y0=0.5, y1=1.0,
-                    fillcolor="#f5e6c0", opacity=0.25, line_width=0)
-        fig.add_shape(type="rect", x0=0, x1=0.5, y0=0.0, y1=0.5,
-                    fillcolor="#d4c0f5", opacity=0.25, line_width=0)
-        fig.add_shape(type="rect", x0=0.5, x1=1.0, y0=0.0, y1=0.5,
-                    fillcolor="#c0f5d0", opacity=0.25, line_width=0)
-
+        fig.add_shape(type="rect", x0=0, x1=0.5, y0=0.5, y1=1.0, fillcolor="#c0d9f5", opacity=0.25, line_width=0)
+        fig.add_shape(type="rect", x0=0.5, x1=1.0, y0=0.5, y1=1.0, fillcolor="#f5e6c0", opacity=0.25, line_width=0)
+        fig.add_shape(type="rect", x0=0, x1=0.5, y0=0.0, y1=0.5, fillcolor="#d4c0f5", opacity=0.25, line_width=0)
+        fig.add_shape(type="rect", x0=0.5, x1=1.0, y0=0.0, y1=0.5, fillcolor="#c0f5d0", opacity=0.25, line_width=0)
         fig.add_hline(y=0.5, line_dash="dash", line_color="#555555", line_width=1.5, opacity=0.8)
         fig.add_vline(x=0.5, line_dash="dash", line_color="#555555", line_width=1.5, opacity=0.8)
-
         for x, y, text, color in [
-            (0.02, 0.98, "Sad & Intense",   "#2a5fa5"),
+            (0.02, 0.98, "Sad & Intense", "#2a5fa5"),
             (0.52, 0.98, "Happy & Intense", "#a57a2a"),
-            (0.02, 0.02, "Sad & Calm",      "#6a2aa5"),
-            (0.52, 0.02, "Happy & Calm",    "#2aa55a"),
+            (0.02, 0.02, "Sad & Calm", "#6a2aa5"),
+            (0.52, 0.02, "Happy & Calm", "#2aa55a"),
         ]:
-            fig.add_annotation(
-                x=x, y=y, text=f"<b>{text}</b>",
-                xref="paper", yref="paper",
-                showarrow=False,
-                font=dict(size=11, color=color),
-                opacity=0.75,
-            )
-
-        fig.update_layout(
-            height=400,
-            margin=dict(l=40, r=40, t=50, b=40),
-            xaxis=dict(range=[0, 1]),
-            yaxis=dict(range=[0, 1]),
-        )
-
+            fig.add_annotation(x=x, y=y, text=f"<b>{text}</b>", xref="paper", yref="paper",
+                               showarrow=False, font=dict(size=11, color=color), opacity=0.75)
+        fig.update_layout(height=400, margin=dict(l=40, r=40, t=50, b=40),
+                          xaxis=dict(range=[0, 1]), yaxis=dict(range=[0, 1]))
         return ui.HTML(fig.to_html(full_html=False, include_plotlyjs=True))
 
-    # =========================================================================
-    # SHUHANG — Results Table and Top Genres render functions
-    # Branch: feat/tables
-    # Results table uses conditional row styling to highlight popular songs (>70)
-    # =========================================================================
     @render.data_frame
     def tbl_results():
         data = filtered_df()[
             ["track_name", "track_artist", "track_album_name",
              "track_album_release_date", "playlist_genre", "track_popularity"]
         ].rename(columns={
-            "track_name": "Song",
-            "track_artist": "Artist",
-            "track_album_name": "Album",
-            "track_album_release_date": "Released",
-            "playlist_genre": "Genre",
-            "track_popularity": "Popularity",
+            "track_name": "Song", "track_artist": "Artist",
+            "track_album_name": "Album", "track_album_release_date": "Released",
+            "playlist_genre": "Genre", "track_popularity": "Popularity",
         }).sort_values("Popularity", ascending=False).reset_index(drop=True)
-
-        # Conditional row styling: highlight high popularity songs in green
         high_pop_rows = data.index[data["Popularity"] >= 70].tolist()
         styles = [{"rows": high_pop_rows, "style": {"background-color": "#d4edda"}}]
-
         return render.DataGrid(data, height="250px", width="100%", styles=styles)
 
     @render.plot
     def tbl_top_genre():
         data = filtered_df()
         fig, ax = plt.subplots(figsize=(4, 3))
-
         if data.empty:
-            ax.text(0.5, 0.5, "No songs match filters",
-                    ha="center", va="center", fontsize=12)
+            ax.text(0.5, 0.5, "No songs match filters", ha="center", va="center", fontsize=12)
             ax.axis("off")
             return fig
-
         top = (
-            data["playlist_genre"]
-            .value_counts()
-            .reset_index()
+            data["playlist_genre"].value_counts().reset_index()
             .rename(columns={"playlist_genre": "Genre", "count": "Count"})
-            .head(6)
-            .sort_values("Count", ascending=True) 
+            .head(6).sort_values("Count", ascending=True)
         )
-
         bars = ax.barh(top["Genre"], top["Count"], color="#1DB954", edgecolor="none")
-
         for bar, val in zip(bars, top["Count"]):
             ax.text(bar.get_width() + 20, bar.get_y() + bar.get_height() / 2,
                     f"{val:,}", va="center", fontsize=9)
-
         ax.set_xlabel("Number of Songs", fontsize=10)
         ax.set_title("Top Genres", fontsize=11, fontweight="bold")
         ax.spines["top"].set_visible(False)
         ax.spines["right"].set_visible(False)
-        ax.set_xlim(0, top["Count"].max() * 1.15)  
+        ax.set_xlim(0, top["Count"].max() * 1.15)
         fig.tight_layout()
         return fig
+
+    # =========================================================================
+    # Tab 2 — AI Explorer server logic
+    # =========================================================================
+
+    @reactive.calc
+    def ai_filtered_df():
+        # qc_state.df() returns a narwhals DataFrame; .to_native() gives us pandas
+        return qc_state.df()
+
+    @render.data_frame
+    def ai_tbl_results():
+        data = ai_filtered_df()[
+            ["track_name", "track_artist", "track_album_name",
+             "track_album_release_date", "playlist_genre", "track_popularity"]
+        ].rename(columns={
+            "track_name": "Song", "track_artist": "Artist",
+            "track_album_name": "Album", "track_album_release_date": "Released",
+            "playlist_genre": "Genre", "track_popularity": "Popularity",
+        }).sort_values("Popularity", ascending=False).reset_index(drop=True)
+        high_pop_rows = data.index[data["Popularity"] >= 70].tolist()
+        styles = [{"rows": high_pop_rows, "style": {"background-color": "#d4edda"}}]
+        return render.DataGrid(data, height="300px", width="100%", styles=styles)
+
+    @render.download(filename="spotifind_ai_filtered.csv")
+    def download_ai_data():
+        yield ai_filtered_df().to_csv(index=False)
+
+    # NOTE: stubs for Team Member 2 to replace on feat/ai-tab-viz
+    @render.ui
+    def ai_plot_mood_map():
+        return ui.p("Mood map coming soon — see feat/ai-tab-viz",
+                    style="text-align:center; padding:2rem; color:grey;")
+
+    @render.plot
+    def ai_tbl_top_genre():
+        fig, ax = plt.subplots(figsize=(4, 3))
+        ax.text(0.5, 0.5, "Top genres coming soon\nsee feat/ai-tab-viz",
+                ha="center", va="center", fontsize=11, color="grey")
+        ax.axis("off")
+        return fig
+
 
 app = App(app_ui, server)


### PR DESCRIPTION
Closes #36 

- Converts `page_fluid` to `page_navbar` to support multiple tabs
- Adds new AI Explorer tab powered by querychat
- Initializes `QueryChat` on a trimmed column subset to reduce token usage
- Wires up `qc.server()` reactive state to filtered dataframe table and download button
- Adds stub render functions for viz (to be replaced in feat/ai-tab-viz)
