### PR TITLE
fix the problem from Feedback from Tiantong Yin

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -68,6 +68,8 @@ def build_mood_map(data, selected_quadrant=""):
     fig.add_trace(go.Scatter(
         x=sample["valence"], y=sample["energy"], mode="markers",
         marker=dict(color=sample["danceability"], colorscale="viridis",
+                    cmin=df["danceability"].min(),
+                    cmax=df["danceability"].max(),
                     size=6, opacity=0.6, colorbar=dict(title="Danceability")),
         customdata=sample[["track_name", "track_artist", "danceability", "valence", "energy"]].values,
         hovertemplate=(


### PR DESCRIPTION
the suggestion: "Mood Map: while filtering I noticed the color gradient scales to the values of the filtered data, and this could be misleading if the user did not notice this and thought a song is more or less danceable than it really is. If you pin the color grading to the min/max danceability of the unfiltered dataset, you would have consistent coloring regardless of the filter (absolute danceability instead of relative danceability)"