### PR TITLE
Display avg energy and danceability as percentages in KPI boxes

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -401,14 +401,14 @@ def server(input, output, session):
         s = filtered_summary()
         if pd.isna(s["avg_energy"]):
             return "—"
-        return f"{s['avg_energy']:.2f} / 1.0"
+        return f"{s['avg_energy']:.0%}"
 
     @render.text
     def kpi_dance():
         s = filtered_summary()
         if pd.isna(s["avg_danceability"]):
             return "—"
-        return f"{s['avg_danceability']:.2f} / 1.0"
+        return f"{s['avg_danceability']:.0%}"
 
     @render.ui
     def plot_mood_map():


### PR DESCRIPTION
## Display KPI values as percentages

Addresses feedback from Tiantong Yin (M4 Feedback Prioritization #57):

- Avg Energy and Avg Danceability are values between 0–1, so displaying
  them as percentages (e.g. `70%`) is more intuitive than fractions
  (e.g. `0.70 / 1.0`) for end users.
