### PR TITLE
Add M3 retrospective and M4 collaboration norms to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,6 @@ There are many ways to contribute, including:
 1.  Fork the repository: https://github.com/UBC-MDS/DSCI-532_2026_37_Spotifind.git
 
 2.  Clone the fork locally using:
-
 ``` bash
 git clone git@github.com:UBC-MDS/DSCI-532_2026_37_Spotifind.git
 ```
@@ -27,13 +26,11 @@ cd DSCI-532_2026_37_Spotifind
 ```
 
 3.  Create the virtual environment with:
-
 ``` bash
 conda env create -f environment.yml
 ```
 
 4.  Once the environment is created, activate it with:
-
 ``` bash
 conda activate spotifind
 ```
@@ -41,7 +38,6 @@ conda activate spotifind
 5. Create a new branch for your feature or bug fix.
 
 6.  Run the app locally with:
-
 ``` bash
 shiny run src/app.py # → http://127.0.0.1:8000
 ```
@@ -77,3 +73,23 @@ LI SHUHANG: lshfan123456@gmail.com
 Jose Davila: jose.dmyt@gmail.com
 
 Thank you for helping make Spotifind great!
+
+---
+
+## M3 Retrospective
+
+**What worked:**
+- Slack communication was consistent and responsive throughout the milestone — the team stayed aligned on progress and blockers.
+
+**What didn't:**
+- Work distribution was unbalanced, with some members carrying a heavier load than others.
+- Several PRs were merged without a proper review, which goes against our agreed workflow and makes it harder to catch bugs early.
+
+## M4 Collaboration Norms
+
+For M4, the team is committing to the following norms:
+
+- **Balanced contributions**: work is explicitly divided so each member owns at least one feature or fix end-to-end.
+- **No unreviewed merges**: every PR must receive at least one approving review from a teammate before merging.
+- **Early completion**: aim to have all work merged by Saturday, March 14, ahead of the Tuesday deadline, to allow time for final testing and the release.
+- **Issue tracking**: every task is tracked as a GitHub Issue and closed via the resolving PR.


### PR DESCRIPTION
## Update CONTRIBUTING.md with M3 retrospective and M4 norms

Adds M3 retrospective (unbalanced workload, PRs merged without review, 
good Slack communication) and M4 collaboration norms (balanced work, 
mandatory PR reviews, early Saturday deadline).

Required for M4 Section 2 (Collaboration).