### PR TITLE
Update spec doc with M4 changes: DuckDB, Option D, feedback addressed

### DIFF
--- a/reports/m2_spec.md
+++ b/reports/m2_spec.md
@@ -6,10 +6,9 @@
 | --- | ------------------------------- | -------------- | ----------------------------- |
 | 1   | When Alex prepares a playlist for his gym morning class on Saturdays, he needs to select the first 15 songs with energy > 0.85 and tempo 135-155 BPM, which allows him to complete the selection within 20 minutes. | ✅ Implemented | Energy and tempo sliders filter songs; results table shows matching songs |
 | 2   | When Alex creates a 'Late Night Focused Study' playlist for clients, he needs to filter 10 songs with a valence < 0.3, acoustics > 0.7, and duration < 240 seconds, so that clients receive the perfect study tracks. | ✅ Implemented | Valence, acousticness, and duration sliders all implemented |
-| 3   | When Alex wants to discover new songs for the dance floor, he needs to look at scatter plots of songs with danceability > 0.8 but popularity < 0.2, so that he can find hidden potential songs that are not yet popular but are suitable for parties, thus improving his reputation. | 🔄 Revised | Danceability and popularity sliders implemented; mood map replaces scatter plot as the primary visual discovery tool |
+| 3   | When Alex wants to discover new songs for the dance floor, he needs to look at scatter plots of songs with danceability > 0.8 but popularity < 0.2, so that he can find hidden potential songs that are not yet popular but are suitable for parties, thus improving his reputation. | 🔄 Revised | Danceability and popularity sliders implemented; mood map replaces scatter plot as the primary visual discovery tool. Quadrant click interaction added in M4 allows direct filtering by mood region. |
 
 ---
-
 
 ## 2.2 Component Inventory
 
@@ -23,13 +22,21 @@
 | `input_duration_s`   | Input         | `ui.input_slider()`     | —                                                                       | #2         |
 | `input_popularity`   | Input         | `ui.input_slider()`     | —                                                                       | #3         |
 | `input_genre_filter` | Input         | `ui.input_select()`     | —                                                                       | #1, #2, #3 |
-| `filtered_df`        | Reactive calc | `@reactive.calc`        | `input_danceability`, `input_tempo`, `input_acousticness`, `input_valence`, `input_energy`, `input_duration_s`, `input_popularity`, `input_genre_filter` | #1, #2, #3 |
-| `kpi_count`          | Output        | `@render.text`          | `filtered_df`                                                           | #1, #2, #3 |
-| `kpi_energy`         | Output        | `@render.text`          | `filtered_df`                                                           | #1         |
-| `kpi_dance`          | Output        | `@render.text`          | `filtered_df`                                                           | #3         |
-| `plot_mood_map`      | Output        | `@render.plot`          | `filtered_df`                                                           | #2, #3     |
+| `clicked_quadrant_raw` | Input       | `ui.input_text()` (hidden) | JS click event on mood map                                           | #3         |
+| `filtered_query`     | Reactive calc | `@reactive.calc`        | all inputs + `clicked_quadrant_raw` | #1, #2, #3 |
+| `filtered_df`        | Reactive calc | `@reactive.calc`        | `filtered_query`                                                        | #1, #2, #3 |
+| `filtered_summary`   | Reactive calc | `@reactive.calc`        | `filtered_query`                                                        | #1, #2, #3 |
+| `kpi_count`          | Output        | `@render.text`          | `filtered_summary`                                                      | #1, #2, #3 |
+| `kpi_energy`         | Output        | `@render.text`          | `filtered_summary`                                                      | #1         |
+| `kpi_dance`          | Output        | `@render.text`          | `filtered_summary`                                                      | #3         |
+| `plot_mood_map`      | Output        | `@render.ui`            | `filtered_df`, `clicked_quadrant`                                       | #2, #3     |
 | `tbl_results`        | Output        | `@render.data_frame`    | `filtered_df`                                                           | #1, #2     |
-| `tbl_top_genre`      | Output        | `@render.data_frame`    | `filtered_df`                                                           | #1, #2, #3 |
+| `tbl_top_genre`      | Output        | `@render.plot`          | `filtered_df`                                                           | #1, #2, #3 |
+| `ai_filtered_df`     | Reactive calc | `@reactive.calc`        | `qc_state.df()`                                                         | #1, #2, #3 |
+| `ai_tbl_results`     | Output        | `@render.data_frame`    | `ai_filtered_df`                                                        | #1, #2, #3 |
+| `ai_plot_mood_map`   | Output        | `@render.ui`            | `ai_filtered_df`                                                        | #2, #3     |
+| `ai_tbl_top_genre`   | Output        | `@render.plot`          | `ai_filtered_df`                                                        | #1, #2, #3 |
+| `download_ai_data`   | Output        | `@render.download`      | `ai_filtered_df`                                                        | #1, #2, #3 |
 
 ---
 
@@ -37,14 +44,15 @@
 
 ```mermaid
 flowchart TD
-  A[/input_danceability/] --> F{{filtered_df}}
-  B[/input_tempo/] --> F
-  C[/input_acousticness/] --> F
-  D[/input_valence/] --> F
-  E[/input_energy/] --> F
-  G[/input_genre_filter/] --> F
-  H[/input_duration_s/] --> F
-  I[/input_popularity/] --> F
+  A[/input_danceability/] --> Q{{filtered_query}}
+  B[/input_tempo/] --> Q
+  C[/input_acousticness/] --> Q
+  D[/input_valence/] --> Q
+  E[/input_energy/] --> Q
+  G[/input_genre_filter/] --> Q
+  H[/input_duration_s/] --> Q
+  I[/input_popularity/] --> Q
+  CQ[/clicked_quadrant_raw/] --> Q
   J[/input_reset_all/] --> R[_reset_filters]
   R --> A
   R --> B
@@ -54,27 +62,78 @@ flowchart TD
   R --> G
   R --> H
   R --> I
-  F --> K1([kpi_count])
-  F --> K2([kpi_energy])
-  F --> K3([kpi_dance])
+  R --> CQ
+  Q --> F{{filtered_df}}
+  Q --> S{{filtered_summary}}
+  S --> K1([kpi_count])
+  S --> K2([kpi_energy])
+  S --> K3([kpi_dance])
   F --> P1([tbl_results])
   F --> P2([tbl_top_genre])
   F --> P3([plot_mood_map])
+  QC[qc_state.df] --> AI{{ai_filtered_df}}
+  AI --> AT([ai_tbl_results])
+  AI --> AM([ai_plot_mood_map])
+  AI --> AG([ai_tbl_top_genre])
+  AI --> DL([download_ai_data])
 ```
 
 ---
 
 ## 2.4 Calculation Details
 
+### `filtered_query`
+
+- **Depends on:** all slider inputs, `input_genre_filter`, `clicked_quadrant_raw`
+- **Transformation:** Constructs a lazy DuckDB/ibis query filtering the parquet dataset to rows matching all slider ranges. If a genre is selected, adds a genre equality filter. If a mood quadrant is selected via click, adds valence and energy range filters for that quadrant. No data is pulled into memory at this stage.
+- **Consumed by:** `filtered_df`, `filtered_summary`
+
 ### `filtered_df`
 
-- **Depends on:** `input_danceability`, `input_tempo`, `input_acousticness`, `input_valence`, `input_energy`, `input_duration_s`, `input_popularity`, `input_genre_filter`
-- **Transformation:** Filters the dataset to rows where danceability, tempo, acousticness, valence, energy, duration, and popularity fall within the selected slider ranges. If a specific genre is selected, further filters to only rows matching that genre.
-- **Consumed by:** `kpi_count`, `kpi_energy`, `kpi_dance`, `plot_mood_map`, `tbl_results`, `tbl_top_genre`
+- **Depends on:** `filtered_query`
+- **Transformation:** Executes the lazy query and materializes the result as a pandas DataFrame via `.to_pandas()`.
+- **Consumed by:** `plot_mood_map`, `tbl_results`, `tbl_top_genre`
+
+### `filtered_summary`
+
+- **Depends on:** `filtered_query`
+- **Transformation:** Executes a DuckDB aggregation query returning row count, average energy, and average danceability. Only three scalar values are pulled into memory, avoiding full materialization for KPI updates.
+- **Consumed by:** `kpi_count`, `kpi_energy`, `kpi_dance`
+
+### `ai_filtered_df`
+
+- **Depends on:** `qc_state.df()`
+- **Transformation:** Returns the pandas DataFrame produced by querychat based on the user's natural language query.
+- **Consumed by:** `ai_tbl_results`, `ai_plot_mood_map`, `ai_tbl_top_genre`, `download_ai_data`
 
 ---
 
-## Complexity Enhancement
+## M4 Changes
+
+### Performance: Parquet + DuckDB
+
+The data layer was switched from loading a CSV into a pandas DataFrame at startup to reading a parquet file via ibis + DuckDB. All filtering now happens as lazy queries at the database level before any data enters memory. A separate `filtered_summary` reactive calc runs a DuckDB aggregation for KPI values, avoiding full DataFrame materialization on every filter change.
+
+### Advanced Feature: Option D — Component Click Interaction
+
+The Mood Map was extended to act as an input component in addition to an output. Clicking on any of the four quadrant regions (Sad & Intense, Happy & Intense, Sad & Calm, Happy & Calm) filters the entire dashboard to songs in that mood region. The click is captured via a Plotly `plotly_click` JavaScript event listener that writes the selected quadrant name into a hidden `ui.input_text`, which Shiny then picks up as a reactive input. Clicking the same quadrant again deselects it. A badge in the sidebar and a checkmark on the map indicate the active quadrant. This was chosen over the other options because it directly enhances the primary visual discovery use case (Job Story #3) without requiring external services or additional API costs.
+
+### Feedback Addressed (M4)
+
+The following items from the M4 Feedback Prioritization issue (#57) were resolved this milestone:
+
+| Item | Source | PR |
+| ---- | ------ | -- |
+| Mood Map color gradient pins to unfiltered min/max danceability | Tiantong Yin (Critical) | #59 |
+| AI tab chat scrolls independently from page | Daniel (Critical) | #60 |
+| Mood Map quadrant labels misaligned on right side; whitespace below chart | Diana Cornescu | #61 |
+| Avg Energy and Avg Danceability displayed as percentages | Tiantong Yin | #62 |
+| AI Explorer — filtered table displayed before visualizations | Diana Cornescu | #64 |
+| Dataframe fills the full card width | Daniel | #65 |
+
+---
+
+## M2 Complexity Enhancement
 
 **Feature: Reset Button**
 


### PR DESCRIPTION
## Update spec doc with M4 decisions

Updates `reports/m2_spec.md` to reflect M4 changes:

- Added `filtered_query` and `filtered_summary` reactive calcs to component inventory and reactivity diagram
- Added all AI Explorer components to component inventory
- Documented Parquet + DuckDB data layer switch
- Documented Option D (quadrant click interaction) advanced feature
- Added feedback addressed table cross-referencing PRs