### PR TITLE
updating PR numbers in CHANGELOG and spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,13 @@
 - Removed whitespace below Mood Map caused by hidden `clicked_quadrant_raw` input rendering as a visible empty text box. Addressed feedback from Diana Cornescu (#57) via #61.
 - Mood Map color gradient now pins to unfiltered dataset min/max danceability values for consistent coloring regardless of active filters. Addressed feedback from Tiantong Yin (Critical, #57) via #59.
 - AI tab chat now scrolls independently from the main page content. Addressed feedback from Daniel (Critical, #57) via #60.
-- AI Explorer filtered table now displays before visualizations for a clearer top-down reading flow. Addressed feedback from Diana Cornescu (#57) via #64.
-- Dataframe now fills the full card width. Addressed feedback from Daniel (#57) via #65.
+- AI Explorer filtered table now displays before visualizations for a clearer top-down reading flow. Addressed feedback from Diana Cornescu (#57) via #69.
+- Dataframe now fills the full card width. Addressed feedback from Daniel (#57) via #71.
+- Test UI results updated to display in percentage format for consistency with KPI boxes (#67).
 
 ### Fixed
 
-- Bugs resolved since M3 are captured in the feedback items above (#59, #60, #61, #62).
+- Bugs resolved since M3 are captured in the feedback items above (#59, #60, #61, #62, #67).
 
 - **Feedback prioritization issue link:** #57
 

--- a/reports/m2_spec.md
+++ b/reports/m2_spec.md
@@ -128,8 +128,9 @@ The following items from the M4 Feedback Prioritization issue (#57) were resolve
 | AI tab chat scrolls independently from page | Daniel (Critical) | #60 |
 | Mood Map quadrant labels misaligned on right side; whitespace below chart | Diana Cornescu | #61 |
 | Avg Energy and Avg Danceability displayed as percentages | Tiantong Yin | #62 |
-| AI Explorer — filtered table displayed before visualizations | Diana Cornescu | #64 |
-| Dataframe fills the full card width | Daniel | #65 |
+| Test UI results updated to percentage format | Nguyen | #67 |
+| AI Explorer filtered table displayed before visualizations | Diana Cornescu | #69 |
+| Dataframe fills the full card width | Daniel | #71 |
 
 ---
 


### PR DESCRIPTION
## Fix PR references in CHANGELOG and spec doc

Updates PR numbers for Jose's and Nguyen's M4 PRs:
- #64 -> #69 (AI Explorer visual order)
- #65 -> #71 (dataframe fill fix)
- Added #67 (test UI percentage format)